### PR TITLE
Improve block storage mount logic

### DIFF
--- a/create-bbb.sh
+++ b/create-bbb.sh
@@ -136,7 +136,10 @@ ssh -o StrictHostKeyChecking=no root@$DROPLET_IP <<EOF
     if ! blkid "${DEVICE}" >/dev/null 2>&1; then
       mkfs.ext4 -F "${DEVICE}"
     fi
-    grep -q "${DEVICE}" /etc/fstab || echo "${DEVICE} /opt/bbb-docker/data ext4 defaults,nofail 0 0" >> /etc/fstab
+    if ! grep -q "${DEVICE}" /etc/fstab; then
+      echo "${DEVICE} /opt/bbb-docker/data ext4 defaults,nofail 0 0" >> /etc/fstab
+      systemctl daemon-reload
+    fi
     mount /opt/bbb-docker/data
   fi
 


### PR DESCRIPTION
## Summary
- mount block storage only if not already configured
- reload systemd when modifying `/etc/fstab`

## Testing
- `apt-get update` *(fails: repository forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68833d2373c08325b842ba8be59e91c2