### PR TITLE
Automatically detect droplet IP during setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This script installs an instance of BigBlueButton on beefy server architecture s
 Copy `sample.env` to `.env` and update the values for your environment.
 `RESERVED_IP` should be set to your DigitalOcean reserved IP so the droplet
 is assigned that address after creation. The droplet's public IP is
-automatically detected when the droplet is created.
+automatically detected when the droplet is created. Use the reserved IP when
+connecting over SSH.
 
 If you have a DigitalOcean block storage volume, set `BLOCK_STORAGE_NAME` to the
 name of that volume and it will be attached and mounted at `/opt/bbb-docker/data`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This script installs an instance of BigBlueButton on beefy server architecture s
 # Usage
 Copy `sample.env` to `.env` and update the values for your environment.
 `RESERVED_IP` should be set to your DigitalOcean reserved IP so the droplet
-is assigned that address after creation.
+is assigned that address after creation. The droplet's public IP is
+automatically detected when the droplet is created.
 
 If you have a DigitalOcean block storage volume, set `BLOCK_STORAGE_NAME` to the
 name of that volume and it will be attached and mounted at `/opt/bbb-docker/data`.

--- a/create-bbb.sh
+++ b/create-bbb.sh
@@ -105,8 +105,9 @@ run_cmd doctl compute droplet create $DROPLET_NAME \
 DROPLET_ID=$(doctl compute droplet list --format ID,Name --no-header | grep "$DROPLET_NAME" | awk '{print $1}')
 echo "📡 Assigning reserved IP '$RESERVED_IP' to droplet..."
 run_cmd doctl compute reserved-ip-action assign $RESERVED_IP $DROPLET_ID
-DROPLET_IP=$RESERVED_IP
-echo "📡 Droplet assigned reserved IP: $DROPLET_IP"
+DROPLET_IP=$(doctl compute droplet list --format PublicIPv4,Name --no-header | awk -v name="$DROPLET_NAME" '$2==name {print $1}')
+echo "📡 Droplet assigned reserved IP: $RESERVED_IP"
+echo "🌐 Droplet IP: $DROPLET_IP"
 
 # Remove any old host key for this IP from known_hosts
 ssh-keygen -R "$DROPLET_IP" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- Derive droplet's public IP from DigitalOcean after creation instead of using reserved IP
- Clarify in README that droplet IP is auto-detected while reserved IP comes from `.env`

## Testing
- `bash -n create-bbb.sh`
- `shellcheck create-bbb.sh` *(fails: command not found)*
- `apt-get update && apt-get install -y shellcheck` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68910357fa3c8325b528540032287e57